### PR TITLE
Fix retroshare path in startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -25,18 +25,17 @@ fi
 
 if [[ $MODE == "nogui" ]]
 then
-	su - retrouser -c "RetroShare06-nogui"
+	su - retrouser -c "retroshare"
 elif [[ $MODE == "nogui-web" ]]
 then
-	su - retrouser -c "RetroShare06-nogui --webinterface 9090 --docroot /usr/share/RetroShare06/webui/ --http-allow-all"
+	su - retrouser -c "retroshare-nogui --webinterface 9090 --docroot /usr/share/retroshare/webui/ --http-allow-all"
 elif [[ $MODE == "gui" ]]
 then
 	#su - retrouser -c "RetroShare06"
 	su - retrouser -c "xpra start :100 --bind-tcp=0.0.0.0:10000 --no-mdns --no-notifications --no-pulseaudio"
 
 	# start RetroShare GUI in a screen session with xpra display
-	su - retrouser -c "DISPLAY=:100 RetroShare06"
+	su - retrouser -c "DISPLAY=:100 retroshare"
 else
 	echo "Wrong mode selected"
 fi
-


### PR DESCRIPTION
Retroshare06 was replaced with retroshare as per [this commit](https://github.com/RetroShare/RetroShare/commit/5bf056c7a472773a53e047e2def1a7953608c16e)